### PR TITLE
Minor cosmetic adjustments in PageRank expression

### DIFF
--- a/tex/appendix_algorithms.tex
+++ b/tex/appendix_algorithms.tex
@@ -37,13 +37,13 @@ This chapter contains pseudo-code for the algorithms described in \sref{sec:defi
 \EndFor
 \For{$i=1,\ldots,\textit{max\_iterations}$}
 \State $\textit{dangling\_sum} \gets 0$
-\ForAll{$v \in V$}
-  \If{$|N_\mathrm{out}(v)| = 0$}
-    \State $\textit{dangling\_sum} \gets \textit{dangling\_sum} + \textit{rank}[v]$
+\ForAll{$w \in V$}
+  \If{$|N_\mathrm{out}(w)| = 0$}
+    \State $\textit{dangling\_sum} \gets \textit{dangling\_sum} + \textit{rank}[w]$
   \EndIf
 \EndFor
 \ForAll{$v \in V$}
-  \State $\textit{new\_rank}[v] \gets (1-d)\frac{1}{|V|} + d \Big( \sum_{u \in N_\mathrm{in}(v)} \frac{\textit{rank}[u]}{|N_\mathrm{out}(u)|} +  \frac{\textit{dangling\_sum}}{|V|} \Big)$
+  \State $\textit{new\_rank}[v] \gets \frac{1-d}{|V|} + d \cdot \sum_{u \in N_\mathrm{in}(v)} \frac{\textit{rank}[u]}{|N_\mathrm{out}(u)|} + \frac{d}{|V|} \cdot \textit{dangling\_sum} $
 \EndFor
 \State $\textit{rank} \gets \textit{new\_rank}$
 \EndFor

--- a/tex/definition.tex
+++ b/tex/definition.tex
@@ -245,7 +245,7 @@ Note that for undirected graphs, each edge is bidirectional so we have $N_\mathr
 
 
 \subsection{PageRank (PR)}
-\emph{PageRank} is an iterative algorithm that assigns to each vertex a ranking value. The algorithm was originally used by Google Search to rank websites in their search results~\cite{page1999pagerank}. Let $\textit{PR}_i(v)$ be the PageRank value of vertex $v$ after iteration $i$. Initially, each vertex $v$ is assigned the same value $1/|V|$ such that the sum of all vertex values is $1$.
+\emph{PageRank} is an iterative algorithm that assigns to each vertex a ranking value. The algorithm was originally used by Google Search to rank websites in their search results~\cite{page1999pagerank}. Let $\textit{PR}_i(v)$ be the PageRank value of vertex $v$ after iteration $i$. Initially, each vertex $v$ is assigned the same value such that the sum of all vertex values is $1$.
 %
 \begin{equation}
 \textit{PR}_0(v) = \frac{1}{|V|}
@@ -254,10 +254,10 @@ Note that for undirected graphs, each edge is bidirectional so we have $N_\mathr
 After iteration $i$, each vertex pushes its PageRank over its outgoing edges to its neighbors. The PageRank for each vertex is updated according to the following rule:
 %
 \begin{equation}
-\textit{PR}_i(v) = \frac{1-d}{|V|} + d \sum_{u \in N_\mathrm{in}(v)} \frac{\textit{PR}_{i - 1}(u)}{|N_\mathrm{out}(u)|} + d \sum_{u \in D} \frac{\textit{PR}_{i - 1}(u)}{|V|}
+\textit{PR}_i(v) = \frac{1-d}{|V|} + d \cdot \sum_{u \in N_\mathrm{in}(v)} \frac{\textit{PR}_{i - 1}(u)}{|N_\mathrm{out}(u)|} + \frac{d}{|V|} \cdot \sum_{w \in D} \textit{PR}_{i - 1}(w)
 \end{equation}
 %
-Where $d \in [0,1]$ is called the \emph{damping factor} and $D = \big\{v \in V \ \big| \ |N_\mathrm{out}(v)| = 0 \big\}$ is the set of \emph{dangling vertices}, i.e., vertices having no outgoing edges. Dangling vertices have nowhere to push their PageRank to, so the total sum of the PageRanks for the dangling vertices is evenly distributed over all vertices. 
+Where $d \in [0,1]$ is called the \emph{damping factor} and $D = \big\{w \in V \ \big| \ |N_\mathrm{out}(w)| = 0 \big\}$ is the set of \emph{dangling vertices}, i.e., vertices having no outgoing edges. Dangling vertices have nowhere to push their PageRank to, so the total sum of the PageRanks for the dangling vertices is evenly distributed over all vertices. 
 
 The PageRank algorithm should continue for a fixed number of iterations. The floating-point values must be handled as 64-bit double-precision IEEE 754 floating-point numbers. 
 


### PR DESCRIPTION
This is totally nitpicking but I changed the PageRank expression from this:
![image](https://user-images.githubusercontent.com/1402801/59163546-df0edf00-8b02-11e9-8481-ba0901c45cfc.png)

to this:
![image](https://user-images.githubusercontent.com/1402801/59163541-d28a8680-8b02-11e9-9fb1-a3ea2cafce68.png)

This change does not introduce any modification in the semantics/value of the expression. However, I hope that it better expresses the fact that the third part (for dangling vertices) is required to be calculated *only once* per iteration, while the second part should be calculated *for each vertex*.